### PR TITLE
normalize by size of masked image, not the unmasked one

### DIFF
--- a/filters/filt.py
+++ b/filters/filt.py
@@ -55,9 +55,9 @@ def _normalize_with_mask(image, percentile, mask):
     vec_mask = mask.reshape((n,))
     sorted_vec = np.sort(vec[vec_mask])
     m = sorted_vec.size
-    mn_ind = np.clip(np.int(n*percentile), 0, m-1)
+    mn_ind = np.clip(np.int(m*percentile), 0, m-1)
     mx_ind = np.clip(m-mn_ind-1, 0, m-1)
-    return _normalize_and_clip(image, sorted_vec[mn_ind], sorted_vec[mx_ind])    
+    return _normalize_and_clip(image, sorted_vec[mn_ind], sorted_vec[mx_ind])
 
 def _normalize_with_no_mask(image, percentile):
     n = image.size
@@ -72,7 +72,7 @@ def _normalize_with_zero_percentile_no_mask(image):
 
 def _normalize_with_zero_percentile_with_mask(image, mask):
     return _normalize_and_clip(image, np.amin(image[mask]), np.amax(image[mask]))
-    
+
 def normalize(image, percentile=0.0, mask=None):
     if mask is None:
         if percentile == 0.0:
@@ -92,7 +92,7 @@ if __name__ == '__main__':
 
     im_comp = im + 0.2
     im_comp = np.random.permutation(im_comp)
-    
+
     # Add outliers
     im_comp[0, 0] = -0.5
     im_comp[3, 4] = 2.0
@@ -111,11 +111,11 @@ if __name__ == '__main__':
     print(res2)
 
     res3 = normalize(im_comp, 0.05, mask)
-    print(res3)    
+    print(res3)
 
     im1 = np.arange(16*8).reshape((16, 8))
     print(im1)
     im1_ds2 = downsample(im1, 2)
     print(im1_ds2)
     im1_ds4 = downsample(im1, 4)
-    print(im1_ds4)    
+    print(im1_ds4)


### PR DESCRIPTION
I was having trouble registering images with rotation. I believe I found [a typo](https://github.com/johanofverstedt/py_alpha_amd_release/pull/1/files#diff-267199e76f9f085f20231c4cd0b95b13R58) which over-normalizes the rotated image by using the size of the whole image not the masked one. With `percentage = 0.15` the difference this creates is more noticeable. 

`n * percentile`
![flo_resampled_2n](https://user-images.githubusercontent.com/5470619/74192076-0aa61400-4c12-11ea-9d2d-6272b5be3bf8.png)

`m * percentile` (this branch)
![flo_resampled_2m](https://user-images.githubusercontent.com/5470619/74192082-0bd74100-4c12-11ea-8ce5-cef267a7af03.png)

Other changes to the file are just white-space trimming which my editor does automatically. I can make the PR the single character change if it's better for you. 
